### PR TITLE
fix explicit nullable deprecation

### DIFF
--- a/src/FunctionalSmokeTester.php
+++ b/src/FunctionalSmokeTester.php
@@ -155,7 +155,7 @@ trait FunctionalSmokeTester
         }
     }
 
-    private function getHttpClientInternal(string $host = null): KernelBrowser
+    private function getHttpClientInternal(?string $host = null): KernelBrowser
     {
         static $client;
 


### PR DESCRIPTION
This fixes a deprecation warning in PHP 8.4