### PR TITLE
add keywords to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "type": "symfony-bundle",
     "license": "LGPL-3.0-or-later",
     "description": "Smoke testing automator for Symfony applications",
+    "keywords": ["testing","dev","symfony"],
     "autoload": {
         "psr-4": {
             "Pierstoval\\SmokeTesting\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "symfony-bundle",
     "license": "LGPL-3.0-or-later",
     "description": "Smoke testing automator for Symfony applications",
-    "keywords": ["testing","dev","symfony"],
+    "keywords": ["testing", "dev", "symfony"],
     "autoload": {
         "psr-4": {
             "Pierstoval\\SmokeTesting\\": "src/"


### PR DESCRIPTION
This will automatically prompt to install the bundle with --dev in case the user forgets.