### PR TITLE
Add option to create tests with TestWith attribute

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,6 +1,6 @@
 name: PHP CI
 
-on: [push]
+on: [pull_request, push]
 
 jobs:
     build-test:

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6|^10.0",
-        "symfony/maker-bundle": "^1.43"
+        "symfony/maker-bundle": "^1.43",
+        "nette/php-generator": "^4.1"
     }
 }

--- a/src/Command/MakeSmokeTestCommand.php
+++ b/src/Command/MakeSmokeTestCommand.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Pierstoval\SmokeTesting\Command;
+
+use Nette\PhpGenerator\PhpNamespace;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\TestWith;
+use Pierstoval\SmokeTesting\FunctionalSmokeTester;
+use Pierstoval\SmokeTesting\FunctionalTestData;
+use Pierstoval\SmokeTesting\RoutesExtractor;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Routing\RouterInterface;
+
+#[AsCommand('generate:smoke', 'Generate the smoke test')]
+final class MakeSmokeTestCommand extends Command
+{
+
+    public function __construct(
+        private readonly RouterInterface                          $router,
+        #[Autowire('%kernel.project_dir%/tests/')] private string $testDir,
+    )
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('className', InputArgument::OPTIONAL, 'Test class name', 'TestStaticRoutes')
+            ->addOption('dto', null, InputOption::VALUE_NONE, 'Create with DTO')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Overwrite existing files');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $routes = RoutesExtractor::extractRoutesFromRouter($this->router);
+        if (!class_exists(PhpNamespace::class)) {
+            $output->writeln("Missing dependency:\n\ncomposer req nette/php-generator");
+            return self::FAILURE;
+        }
+        $namespace = new PhpNamespace('Tests');
+        foreach ([
+                     FunctionalSmokeTester::class,
+                     WebTestCase::class,
+                     TestDox::class,
+                     TestWith::class,
+                     KernelBrowser::class,
+                     FunctionalTestData::class
+                 ] as $useClass) {
+            $namespace->addUse($useClass);
+        }
+
+
+// create new classes in the namespace
+        $class = $namespace->addClass($testClassName = 'TestStaticRoutes');
+        $class->setExtends(WebTestCase::class);
+        $namespace->add($class);
+
+        $class->addTrait(FunctionalSmokeTester::class);
+
+        $method = $class->addMethod('testRoute');
+        $method->setReturnType('void');
+//        #[TestDox('/$method $url ($route)')]
+        $method->addAttribute(TestDox::class, [
+            '/$method $url ($route)'
+        ]);
+        // get the routes
+        foreach ($routes as $route) {
+            //        #[TestWith(['GET', '/app', 'app_app'])]
+            $method->addAttribute(TestWith::class,
+                [
+                    [
+                        $route['httpMethod'],
+                        $route['routePath'],
+                        $route['routeName']
+                    ]
+                ]);
+        }
+
+        array_map(fn($param) => $method->addParameter($param)->setType('string'), [
+            'method', 'url', 'route'
+        ]);
+//        public function testRoute(string $method, string $url, string $route): void
+        if ($dto = $input->getOption('dto')) {
+            $method->setBody(<<<'END'
+        $this->runFunctionalTest(
+            FunctionalTestData::withUrl($url)
+                ->withMethod($method)
+                ->expectRouteName($route)
+                ->appendCallableExpectation($this->assertStatusCodeLessThan500($method, $url))
+        );
+END
+            );
+
+            $method = $class->addMethod('assertStatusCodeLessThan500');
+            array_map(fn($param) => $method->addParameter($param)->setType('string'), [
+                'method', 'url'
+            ]);
+            $method->setReturnType('\Closure');
+            $method->setBody(<<<'END'
+                return function (KernelBrowser $browser) use ($method, $url) {
+                    $statusCode = $browser->getResponse()->getStatusCode();
+                    $routeName = $browser->getRequest()->attributes->get('_route', 'unknown');
+
+                    static::assertLessThan(
+                        500,
+                        $statusCode,
+                        sprintf('Request "%s %s" for %s route returned an internal error.', $method, $url, $routeName),
+                    );
+                };
+    END
+            );
+
+        }
+        $filename = $this->testDir . $input->getArgument('className') . '.php';
+        if ($input->getOption('force') || !file_exists($filename)) {
+            file_put_contents($filename, "<?php\n\n" . $namespace);
+        }
+        $output->writeln(sprintf('<info>%s</info> written.', $filename));
+
+        return self::SUCCESS;
+
+    }
+
+
+}

--- a/src/Maker/Resources/FunctionalSmokeAttributesTest.tpl.php
+++ b/src/Maker/Resources/FunctionalSmokeAttributesTest.tpl.php
@@ -4,6 +4,7 @@ echo "<?php\n"; ?>
 namespace <?php echo $namespace; ?>;
 
 use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\Attributes\TestDox;
 <?php if ($with_dto): ?>
 use Pierstoval\SmokeTesting\FunctionalSmokeTester;
 use Pierstoval\SmokeTesting\FunctionalTestData;
@@ -21,6 +22,7 @@ class <?php echo $class_name; ?> extends WebTestCase
     #[TestWith(['<?php echo $route['routePath']; ?>','<?php echo $route['routeName']; ?>', '<?php echo $route['httpMethod']; ?>'])]
     <?php endif; ?>
     <?php endforeach; ?>
+    #[TestDox('/$method $url ($route)')]
     public function testRoute(string $url, string $route, string $method='GET'): void
     {
 <?php if ($with_dto): ?>

--- a/src/Maker/Resources/FunctionalSmokeAttributesTest.tpl.php
+++ b/src/Maker/Resources/FunctionalSmokeAttributesTest.tpl.php
@@ -19,11 +19,11 @@ class <?php echo $class_name; ?> extends WebTestCase
 <?php endif; ?>
 <?php foreach ($routes as $route): ?>
     <?php if (!str_starts_with($route['routePath'], '/_')): ?>
-    #[TestWith(['<?php echo $route['routePath']; ?>','<?php echo $route['routeName']; ?>', '<?php echo $route['httpMethod']; ?>'])]
+    #[TestWith(['<?php echo $route['httpMethod']; ?>', '<?php echo $route['routePath']; ?>','<?php echo $route['routeName']; ?>'])]
     <?php endif; ?>
     <?php endforeach; ?>
     #[TestDox('/$method $url ($route)')]
-    public function testRoute(string $url, string $route, string $method='GET'): void
+    public function testRoute(string $method, string $url, string $route): void
     {
 <?php if ($with_dto): ?>
         $this->runFunctionalTest(

--- a/src/Maker/Resources/FunctionalSmokeAttributesTest.tpl.php
+++ b/src/Maker/Resources/FunctionalSmokeAttributesTest.tpl.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+echo "<?php\n"; ?>
+
+namespace <?php echo $namespace; ?>;
+
+use PHPUnit\Framework\Attributes\TestWith;
+<?php if ($with_dto): ?>
+use Pierstoval\SmokeTesting\FunctionalSmokeTester;
+use Pierstoval\SmokeTesting\FunctionalTestData;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+<?php endif; ?>
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class <?php echo $class_name; ?> extends WebTestCase
+{
+<?php if ($with_dto): ?>
+    use FunctionalSmokeTester;
+<?php endif; ?>
+<?php foreach ($routes as $route): ?>
+    <?php if (!str_starts_with($route['routePath'], '/_')): ?>
+    #[TestWith(['<?php echo $route['routePath']; ?>','<?php echo $route['routeName']; ?>', '<?php echo $route['httpMethod']; ?>'])]
+    <?php endif; ?>
+    <?php endforeach; ?>
+    public function testRoute(string $url, string $route, string $method='GET'): void
+    {
+<?php if ($with_dto): ?>
+        $this->runFunctionalTest(
+            FunctionalTestData::withUrl($url)
+                ->withMethod($method)
+                ->expectRouteName($route)
+                ->appendCallableExpectation($this->assertStatusCodeLessThan500($method, $url))
+        );
+<?php else: ?>
+    $client = static::createClient();
+    $crawler = $client->request('GET', '/');
+
+    static::assertLessThan(
+    500,
+    $client->getResponse()->getStatusCode(),
+    'Request "$method $url for route $routeName returned an internal error.',
+    );
+<?php endif; ?>
+
+    }
+
+<?php if ($with_dto): ?>
+    public function assertStatusCodeLessThan500(string $method, string $url): \Closure
+    {
+        return function (KernelBrowser $browser) use ($method, $url) {
+            $statusCode = $browser->getResponse()->getStatusCode();
+            $routeName = $browser->getRequest()->attributes->get('_route', 'unknown');
+
+            static::assertLessThan(
+                500,
+                $statusCode,
+                sprintf('Request "%s %s" for %s route returned an internal error.', $method, $url, $routeName),
+            );
+        };
+    }
+<?php endif; ?>}

--- a/src/SmokeTestingBundle.php
+++ b/src/SmokeTestingBundle.php
@@ -2,6 +2,7 @@
 
 namespace Pierstoval\SmokeTesting;
 
+use Pierstoval\SmokeTesting\Command\MakeSmokeTestCommand;
 use Pierstoval\SmokeTesting\Maker\MakeSmokeTests;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -11,6 +12,11 @@ class SmokeTestingBundle extends Bundle
     public function build(ContainerBuilder $container): void
     {
         $container->register(MakeSmokeTests::class)
+            ->setAutowired(true)
+            ->setAutoconfigured(true)
+        ;
+        $container->register(MakeSmokeTestCommand::class)
+            ->setPublic(true)
             ->setAutowired(true)
             ->setAutoconfigured(true)
         ;


### PR DESCRIPTION
adding --attributes to make:smoke-tests now generates the testing use the TestWith attribute.  It requires a later version of phpunit and at least php 8.

The final file file is significantly shorter.

```php
<?php

namespace App\Tests;

use PHPUnit\Framework\Attributes\TestWith;
use Pierstoval\SmokeTesting\FunctionalSmokeTester;
use Pierstoval\SmokeTesting\FunctionalTestData;
use Symfony\Bundle\FrameworkBundle\KernelBrowser;
use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;

class FunctionalTest extends WebTestCase
{
    use FunctionalSmokeTester;

    #[TestWith(['/api', 'api_entrypoint', 'GET'])]
    #[TestWith(['/api', 'api_entrypoint', 'HEAD'])]
    #[TestWith(['/api/docs', 'api_doc', 'GET'])]
    #[TestWith(['/api/docs', 'api_doc', 'HEAD'])]
    #[TestWith(['/api/reactions', 'reactions_doctrine', 'GET'])]
    #[TestWith(['/api/talks', 'meili_talk', 'GET'])]
    #[TestWith(['/js/routing', 'fos_js_routing_js', 'GET'])]
    #[TestWith(['/auth/profile', 'oauth_profile', 'GET'])]
    #[TestWith(['/auth/providers', 'oauth_providers', 'GET'])]
    #[TestWith(['/crawler/crawlerdata', 'survos_crawler_data', 'GET'])]
    #[TestWith(['/workflow/workflows', 'survos_workflows', 'GET'])]
    #[TestWith(['/logout', 'app_logout', 'GET'])]
    #[TestWith(['/', 'app_homepage', 'GET'])]
    #[TestWith(['/register', 'app_register', 'GET'])]
    #[TestWith(['/verify/email', 'app_verify_email', 'GET'])]
    #[TestWith(['/login', 'app_login', 'GET'])]
    #[TestWith(['/talks/browse/', 'talk_browse', 'GET'])]
    #[TestWith(['/talks/', 'talk_index', 'GET'])]
    #[TestWith(['/talks/symfony_crud_index', 'talk_symfony_crud_index', 'GET'])]
    #[TestWith(['/talkstalk/new', 'talk_new', 'GET'])]
    public function testRoute(string $url, string $route, string $method = 'GET'): void
    {
        $this->runFunctionalTest(
            FunctionalTestData::withUrl($url)
                ->withMethod($method)
                ->expectRouteName($route)
                ->appendCallableExpectation($this->assertStatusCodeLessThan500($method, $url))
        );
    }

    public function assertStatusCodeLessThan500(string $method, string $url): \Closure
    {
        return function (KernelBrowser $browser) use ($method, $url) {
            $statusCode = $browser->getResponse()->getStatusCode();
            $routeName = $browser->getRequest()->attributes->get('_route', 'unknown');

            static::assertLessThan(
                500,
                $statusCode,
                sprintf('Request "%s %s" for %s route returned an internal error.', $method, $url, $routeName),
            );
        };
    }
}
```
